### PR TITLE
Methods marked with @UiThread must be executed on the main thread.

### DIFF
--- a/android/src/main/java/com/vitanov/multiimagepicker/MultiImagePickerPlugin.java
+++ b/android/src/main/java/com/vitanov/multiimagepicker/MultiImagePickerPlugin.java
@@ -140,7 +140,7 @@ public class MultiImagePickerPlugin implements
 
     }
 
-    private static class GetThumbnailTask extends AsyncTask<String, Void, Void> {
+    private static class GetThumbnailTask extends AsyncTask<String, Void, ByteBuffer> {
         private WeakReference<Activity> activityReference;
         BinaryMessenger messenger;
         final String identifier;
@@ -159,7 +159,7 @@ public class MultiImagePickerPlugin implements
         }
 
         @Override
-        protected Void doInBackground(String... strings) {
+        protected ByteBuffer doInBackground(String... strings) {
             final Uri uri = Uri.parse(this.identifier);
             byte[] byteArray = null;
 
@@ -187,10 +187,18 @@ public class MultiImagePickerPlugin implements
             if (byteArray != null) {
                 buffer = ByteBuffer.allocateDirect(byteArray.length);
                 buffer.put(byteArray);
+                return buffer;
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(ByteBuffer buffer) {
+            super.onPostExecute(buffer);
+            if (buffer != null) {
                 this.messenger.send("multi_image_picker/image/" + this.identifier + ".thumb", buffer);
                 buffer.clear();
             }
-            return null;
         }
     }
 
@@ -254,7 +262,7 @@ public class MultiImagePickerPlugin implements
         }
     }
 
-    private static class GetImageTask extends AsyncTask<String, Void, Void> {
+    private static class GetImageTask extends AsyncTask<String, Void, ByteBuffer> {
         private final WeakReference<Activity> activityReference;
 
         final BinaryMessenger messenger;
@@ -270,7 +278,7 @@ public class MultiImagePickerPlugin implements
         }
 
         @Override
-        protected Void doInBackground(String... strings) {
+        protected ByteBuffer doInBackground(String... strings) {
             final Uri uri = Uri.parse(this.identifier);
             byte[] bytesArray = null;
 
@@ -295,9 +303,14 @@ public class MultiImagePickerPlugin implements
             assert bytesArray != null;
             final ByteBuffer buffer = ByteBuffer.allocateDirect(bytesArray.length);
             buffer.put(bytesArray);
+            return buffer;
+        }
+
+        @Override
+        protected void onPostExecute(ByteBuffer buffer) {
+            super.onPostExecute(buffer);
             this.messenger.send("multi_image_picker/image/" + this.identifier + ".original", buffer);
             buffer.clear();
-            return null;
         }
     }
 


### PR DESCRIPTION
Android app crashed when invoke method asset.requestOriginal(quality: 80).then((data) { ... }.

crash thread stack details:
D/HwAppInnerBoostImpl(22519): asyncReportData com.xibao.rich_editor,1,2,1,3 interval=1988
W/InputMethodManager(22519): startInputReason = 1
D/HwAppInnerBoostImpl(22519): asyncReportData com.xibao.rich_editor,1,1,6,0 interval=2064
E/AndroidRuntime(22519): FATAL EXCEPTION: AsyncTask #4
E/AndroidRuntime(22519): Process: com.xibao.rich_editor, PID: 22519
E/AndroidRuntime(22519): java.lang.RuntimeException: An error occurred while executing doInBackground()
E/AndroidRuntime(22519): 	at android.os.AsyncTask$3.done(AsyncTask.java:366)
E/AndroidRuntime(22519): 	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
E/AndroidRuntime(22519): 	at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
E/AndroidRuntime(22519): 	at java.util.concurrent.FutureTask.run(FutureTask.java:271)
E/AndroidRuntime(22519): 	at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:257)
E/AndroidRuntime(22519): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
E/AndroidRuntime(22519): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
E/AndroidRuntime(22519): 	at java.lang.Thread.run(Thread.java:784)
E/AndroidRuntime(22519): Caused by: java.lang.RuntimeException: Methods marked with @UiThread must be executed on the main thread. Current thread: AsyncTask #4
E/AndroidRuntime(22519): 	at io.flutter.embedding.engine.FlutterJNI.ensureRunningOnMainThread(FlutterJNI.java:605)
E/AndroidRuntime(22519): 	at io.flutter.embedding.engine.FlutterJNI.dispatchPlatformMessage(FlutterJNI.java:515)
E/AndroidRuntime(22519): 	at io.flutter.embedding.engine.dart.DartMessenger.send(DartMessenger.java:76)
E/AndroidRuntime(22519): 	at io.flutter.embedding.engine.dart.DartExecutor.send(DartExecutor.java:151)
E/AndroidRuntime(22519): 	at io.flutter.view.FlutterNativeView.send(FlutterNativeView.java:144)
E/AndroidRuntime(22519): 	at com.vitanov.multiimagepicker.MultiImagePickerPlugin$GetImageTask.doInBackground(MultiImagePickerPlugin.java:298)
E/AndroidRuntime(22519): 	at com.vitanov.multiimagepicker.MultiImagePickerPlugin$GetImageTask.doInBackground(MultiImagePickerPlugin.java:257)
E/AndroidRuntime(22519): 	at android.os.AsyncTask$2.call(AsyncTask.java:345)
E/AndroidRuntime(22519): 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)

########################################################
multi_image_picker: ^4.3.2

flutter doctor:
[√] Flutter (Channel master, v1.6.4-pre.16, on Microsoft Windows [Version 10.0.17134.345], locale zh-CN)

[√] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
[!] Android Studio (version 2.3)
    X Flutter plugin not installed; this adds Flutter specific functionality.
    X Dart plugin not installed; this adds Dart specific functionality.
[√] Android Studio (version 3.2)
[√] Connected device (1 available)
