### PR TITLE
CI build on different channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 os:
   - linux
 sudo: false
+env:
+  - CHANNEL=stable
+  - CHANNEL=beta
+  - CHANNEL=dev
+  #- CHANNEL=master
 addons:
   apt:
     # Flutter depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18
@@ -10,7 +15,7 @@ addons:
       - libstdc++6
       - fonts-droid-fallback
 before_script:
-  - git clone https://github.com/flutter/flutter.git -b beta
+  - git clone https://github.com/flutter/flutter.git -b $CHANNEL
   - ./flutter/bin/flutter doctor
 script:
   - ./flutter/bin/flutter test


### PR DESCRIPTION
Some breaking changes on ImageProvider API has rolled out to flutter dev channel, do you think it's good idea to separate out AssetThumbImageProvider to another package to make current package compatible with flutter dev channel?