### PR TITLE
Fixed Android 10 not loading gps information from picture

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 19

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     lintOptions {
         disable 'InvalidPackage'
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "com.vitanov.multiimagepickerexample"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
This is a fix for #232 

Three main changes
* Upgraded `compileSdkVersion` and `targetSdkVersion` to 29
* If Android Q or above, I ask for original url using `uri = MediaStore.setRequireOriginal(uri);`. That gives me the media url with GPS information
* If Android Q or above, I use a different `getLatLng` that is specific for this Android version.