### PR TITLE
Fix basicUsage sample

### DIFF
--- a/docs/basicusage.md
+++ b/docs/basicusage.md
@@ -27,17 +27,20 @@ class _MyAppState extends State<MyApp> {
   }
 
   Widget buildGridView() {
-    return GridView.count(
-      crossAxisCount: 3,
-      children: List.generate(images.length, (index) {
-        Asset asset = images[index];
-        return AssetThumb(
-          asset: asset,
-          width: 300,
-          height: 300,
-        );
-      }),
-    );
+    if (images != null)
+      return GridView.count(
+        crossAxisCount: 3,
+        children: List.generate(images.length, (index) {
+          Asset asset = images[index];
+          return AssetThumb(
+            asset: asset,
+            width: 300,
+            height: 300,
+          );
+        }),
+      );
+    else
+      return Container(color: Colors.white);
   }
 
   Future<void> loadAssets() async {
@@ -53,7 +56,7 @@ class _MyAppState extends State<MyApp> {
         maxImages: 300,
       );
     } on Exception catch (e) {
-      error = e.message;
+      error = e.toString();
     }
 
     // If the widget was removed from the tree while the asynchronous platform


### PR DESCRIPTION
BasicUsage sample was not compiling under Flutter 1.12.13 and if we press cancel, the app is crashing as no test is done on the actual result of the selection images is null so images.length crashed