### PR TITLE
Adding support for Android API Level 16 and up

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ android {
     compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/src/main/java/com/vitanov/multiimagepicker/FileDirectory.java
+++ b/android/src/main/java/com/vitanov/multiimagepicker/FileDirectory.java
@@ -1,5 +1,6 @@
 package com.vitanov.multiimagepicker;
 
+import android.annotation.SuppressLint;
 import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
@@ -9,6 +10,9 @@ import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 
+import androidx.loader.content.CursorLoader;
+
+// https://gist.github.com/tatocaster/32aad15f6e0c50311626
 
 public class FileDirectory {
 
@@ -21,7 +25,25 @@ public class FileDirectory {
      * @param uri The Uri to query.
      * @author paulburke
      */
-    public static String getPath(final Context context, final Uri uri) {
+    public static String getPath(final Context context, final Uri uri){
+        String _path;
+        // SDK < API11
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            _path = getPath_BelowAPI11(context, uri);
+        }
+        // SDK >= 11 && SDK < 19
+        else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+            _path = getPath_API11to18(context, uri);
+        }
+        // SDK > 19 (Android 4.4) and up
+        else {
+            _path = getPath_API19(context, uri);
+        }
+        return _path;
+    }
+
+    @SuppressLint("NewApi")
+    public static String getPath_API19(final Context context, final Uri uri) {
 
         final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
@@ -83,6 +105,38 @@ public class FileDirectory {
         return null;
     }
 
+    @SuppressLint("NewApi")
+    public static String getPath_API11to18(Context context, Uri contentUri) {
+        String[] proj = {MediaStore.Images.Media.DATA};
+        String result = null;
+
+        CursorLoader cursorLoader = new CursorLoader(context, contentUri, proj, null, null, null);
+        Cursor cursor = cursorLoader.loadInBackground();
+
+        if (cursor != null) {
+            int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+            cursor.moveToFirst();
+            result = cursor.getString(column_index);
+            cursor.close();
+        }
+        return result;
+    }
+
+    public static String getPath_BelowAPI11(final Context context, final Uri contentUri) {
+        String[] proj = {MediaStore.Images.Media.DATA};
+        Cursor cursor = context.getContentResolver().query(contentUri, proj, null, null, null);
+        int column_index = 0;
+        String result = "";
+        if (cursor != null) {
+            column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+            cursor.moveToFirst();
+            result = cursor.getString(column_index);
+            cursor.close();
+            return result;
+        }
+        return result;
+    }
+
     /**
      * Get the value of the data column for this Uri. This is useful for
      * MediaStore Uris, and other file-based ContentProviders.
@@ -97,14 +151,19 @@ public class FileDirectory {
                                         String[] selectionArgs) {
 
         final String column = "_data";
+        Cursor cursor = null;
         final String[] projection = {
                 column
         };
-        try (Cursor cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-                null)) {
+        try{
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
             if (cursor != null && cursor.moveToFirst()) {
                 final int column_index = cursor.getColumnIndexOrThrow(column);
                 return cursor.getString(column_index);
+            }
+        }finally {
+            if(cursor != null){
+                cursor.close();
             }
         }
         return null;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -8,7 +8,7 @@ if (localPropertiesFile.exists()) {
 
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+    throw new FileNotFoundException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # This is a generated file; do not edit or check into version control.
-export "FLUTTER_ROOT=/Users/radoslav/Projects/flutter"
-export "FLUTTER_APPLICATION_PATH=/Users/radoslav/Projects/multi_image_picker/example"
-export "FLUTTER_TARGET=lib/main.dart"
+export "FLUTTER_ROOT=D:\flutter\flutter"
+export "FLUTTER_APPLICATION_PATH=D:\flutter\workspace\multi_image_picker\example"
+export "FLUTTER_TARGET=lib\main.dart"
 export "FLUTTER_BUILD_DIR=build"
-export "SYMROOT=${SOURCE_ROOT}/../build/ios"
-export "FLUTTER_FRAMEWORK_DIR=/Users/radoslav/Projects/flutter/bin/cache/artifacts/engine/ios"
+export "SYMROOT=${SOURCE_ROOT}/../build\ios"
+export "FLUTTER_FRAMEWORK_DIR=D:\flutter\flutter\bin\cache\artifacts\engine\ios"
 export "FLUTTER_BUILD_NAME=1.0.0"
 export "FLUTTER_BUILD_NUMBER=1"


### PR DESCRIPTION
I added some functions to take into account the different API Levels.
I completely rewrite the `getOrientation` function since you were using MediaStore.Images.ImageColumns.ORIENTATION which was introduced in API Level 29. I used `ExifInterface`.
Some of the code to support API Level < 19 was taken from `https://gist.github.com/tatocaster/32aad15f6e0c50311626`