### PR TITLE
update links of sidebar `API Reference`

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -23,7 +23,7 @@
 - [Upgrading](upgrading.md)
 
 - API Reference
-  - [Asset](https://pub.dartlang.org/documentation/multi_image_picker/latest/asset/Asset-class.html)
-  - [Metadata](https://pub.dartlang.org/documentation/multi_image_picker/latest/metadata/Metadata-class.html)
-  - [MultiImagePicker](https://pub.dartlang.org/documentation/multi_image_picker/latest/picker/MultiImagePicker-class.html)
+  - [Asset](https://pub.dartlang.org/documentation/multi_image_picker/latest/multi_image_picker/Asset-class.html)
+  - [Metadata](https://pub.dartlang.org/documentation/multi_image_picker/latest/multi_image_picker/Metadata-class.html)
+  - [MultiImagePicker](https://pub.dartlang.org/documentation/multi_image_picker/latest/multi_image_picker/MultiImagePicker-class.html)
   - [multi_image_picker](https://pub.dartlang.org/documentation/multi_image_picker/latest/multi_image_picker/multi_image_picker-library.html)


### PR DESCRIPTION
### Description
Update links of sidebar `API Reference`.
Original links are connected to `404` page.