### PR TITLE
Exclude Gifs

### DIFF
--- a/android/src/main/java/com/vitanov/multiimagepicker/MultiImagePickerPlugin.java
+++ b/android/src/main/java/com/vitanov/multiimagepicker/MultiImagePickerPlugin.java
@@ -498,7 +498,7 @@ public class MultiImagePickerPlugin implements
                 .setCamera(enableCamera)
                 .setRequestCode(REQUEST_CODE_CHOOSE)
                 .setSelectedImages(selectedUris)
-                .exceptGif(true)
+                .exceptMimeType(listOf(MimeType.GIF))
                 .setIsUseDetailView(useDetailsView.equals("true"))
                 .setReachLimitAutomaticClose(autoCloseOnSelectionLimit.equals("true"))
                 .isStartInAllView(startInAllView.equals("true"));


### PR DESCRIPTION
It seems like the exceptGif is not working. When we use this package gifs still show up although they are greyed out. When they are imported our app crashes. 

`exceptGif` is deprecated in the library. PR is switching to the replacement `exceptMimeType(listOf(MimeType.GIF))` 

This could be expanded in the future to give users the option to specify the formats they'd like to exclude.