### PR TITLE
Fix on iOS can't present picker in some cases

### DIFF
--- a/ios/Classes/SwiftMultiImagePickerPlugin.swift
+++ b/ios/Classes/SwiftMultiImagePickerPlugin.swift
@@ -62,7 +62,6 @@ public class SwiftMultiImagePickerPlugin: NSObject, FlutterPlugin {
             }
             
             let vc = BSImagePickerViewController()
-//            vc.modalPresentationStyle = .fullScreen
             vc.navigationBar.isTranslucent = false
             
             if #available(iOS 13.0, *) {


### PR DESCRIPTION
On iOS latest flutter sdk, FlutterAppDelegate's flutterEngine property is removed.
If rootViewController has presentedViewController, picker can't present.