### PR TITLE
fix camera permission on android SDK 29

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.vitanov.example">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
@@ -12,6 +11,7 @@
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="example"
+        android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
MANAGE_EXTERNAL_STORAGE permission removed, because of Google refusing app which are using it (https://support.google.com/googleplay/android-developer/answer/9956427?hl=en) until early 2021

requestLegacyExternalStorage property added to fix this issue on SDK 29 ONLY