### PR TITLE
Android: added requireOriginal option to requestMetadata

### DIFF
--- a/android/src/main/java/com/vitanov/multiimagepicker/MultiImagePickerPlugin.java
+++ b/android/src/main/java/com/vitanov/multiimagepicker/MultiImagePickerPlugin.java
@@ -287,11 +287,12 @@ public class MultiImagePickerPlugin implements
             }
         } else if (REQUEST_METADATA.equals(call.method)) {
             final String identifier = call.argument("identifier");
+            final Boolean requireOriginal = call.argument("requireOriginal");
 
             Uri uri = Uri.parse(identifier);
 
             // Scoped storage related code. We can only get gps location if we ask for original image
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (requireOriginal && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 uri = MediaStore.setRequireOriginal(uri);
             }
 

--- a/lib/src/picker.dart
+++ b/lib/src/picker.dart
@@ -158,7 +158,12 @@ class MultiImagePicker {
     }
   }
 
-  // Requests image metadata for a given [identifier]
+  /// Requests image metadata for a given [identifier]
+  ///
+  /// [requireOriginal] calls MediaStore.setRequireOriginal
+  /// on Android which will retrieve privacy-sensitive EXIF
+  /// tags like location but one must hold the ACCESS_MEDIA_LOCATION
+  /// permission starting from Android Q.
   static Future<Metadata> requestMetadata(String identifier, {bool requireOriginal = false}) async {
     Map<dynamic, dynamic> map = await _channel.invokeMethod(
       "requestMetadata",

--- a/lib/src/picker.dart
+++ b/lib/src/picker.dart
@@ -159,11 +159,12 @@ class MultiImagePicker {
   }
 
   // Requests image metadata for a given [identifier]
-  static Future<Metadata> requestMetadata(String identifier) async {
+  static Future<Metadata> requestMetadata(String identifier, {bool requireOriginal = false}) async {
     Map<dynamic, dynamic> map = await _channel.invokeMethod(
       "requestMetadata",
       <String, dynamic>{
         "identifier": identifier,
+        "requireOriginal": requireOriginal,
       },
     );
 


### PR DESCRIPTION
Enable not requesting location info, as this requires ACCESS_MEDIA_LOCATION permission in Android Q.

Fix for "java.lang.UnsupportedOperationException: Caller must hold ACCESS_MEDIA_LOCATION permission to access original" (#557) for apps that don't require location.

Confirmed to fix this exception on a user's device.