### PR TITLE
fix exceptions to match documentation

### DIFF
--- a/lib/src/picker.dart
+++ b/lib/src/picker.dart
@@ -76,6 +76,10 @@ class MultiImagePicker {
       switch (e.code) {
         case "CANCELLED":
           throw NoImagesSelectedException(e.message);
+        case "PERMISSION_DENIED":
+          throw PermissionDeniedException(e.message);
+        case "PERMISSION_PERMANENTLY_DENIED":
+          throw PermissionPermanentlyDeniedExeption(e.message);
         default:
           throw e;
       }

--- a/test/multi_image_picker_test.dart
+++ b/test/multi_image_picker_test.dart
@@ -126,6 +126,39 @@ void main() {
           throwsArgumentError,
         );
       });
+
+      test('throws correct exception on cancel', () {
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          throw PlatformException(code: 'CANCELLED');
+        });
+
+        expect(
+          () => MultiImagePicker.pickImages(maxImages: 10),
+          throwsA(isA<NoImagesSelectedException>()),
+        );
+      });
+
+      test('throws correct exception when permission denied', () {
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          throw PlatformException(code: 'PERMISSION_DENIED');
+        });
+
+        expect(
+          () => MultiImagePicker.pickImages(maxImages: 10),
+          throwsA(isA<PermissionDeniedException>()),
+        );
+      });
+
+      test('throws correct exception when permission permanently denied', () {
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          throw PlatformException(code: 'PERMISSION_PERMANENTLY_DENIED');
+        });
+
+        expect(
+          () => MultiImagePicker.pickImages(maxImages: 10),
+          throwsA(isA<PermissionPermanentlyDeniedExeption>()),
+        );
+      });
     });
 
     test('requestOriginal accepts correct params', () async {


### PR DESCRIPTION
Looks like the [documentation](https://sh1d0w.github.io/multi_image_picker/#/errorhandling) lists some exceptions that aren't actually being thrown. Let me know if you want me to change anything!