### PR TITLE
Fix: "error: compiling for iOS 9.0, but module 'BSGridCollectionViewLayout' has a minimum deployment target of iOS 10.0"

### DIFF
--- a/ios/multi_image_picker.podspec
+++ b/ios/multi_image_picker.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'BSImagePicker', '~> 3.3.1'
+  s.dependency 'BSImagePicker', '~> 2.10.3'
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 s.swift_version = '5.0'

--- a/ios/multi_image_picker.podspec
+++ b/ios/multi_image_picker.podspec
@@ -19,6 +19,6 @@ A new flutter plugin project.
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 s.swift_version = '5.0'
-  s.ios.deployment_target = ’10.0’
+  s.ios.deployment_target = '10.0'
 end
 

--- a/ios/multi_image_picker.podspec
+++ b/ios/multi_image_picker.podspec
@@ -15,10 +15,10 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'BSImagePicker', '~> 2.10.3'
+  s.dependency 'BSImagePicker', '~> 3.3.1'
 
   s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
 s.swift_version = '5.0'
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = ’10.0’
 end
 


### PR DESCRIPTION
The library cannot be used and an error `"error: compiling for iOS 9.0, but module 'BSGridCollectionViewLayout' has a minimum deployment target of iOS 10.0"` is seen.

You can temporarily use the following in `pubspec.yaml` to use this fix:

```
  multi_image_picker:
    git:
      url: https://github.com/fzyzcjy/multi_image_picker
      ref: master
```

Closes https://github.com/Sh1d0w/multi_image_picker/issues/637
